### PR TITLE
Invalid Data Fixes

### DIFF
--- a/Almanac/Crops/VanillaProvider.cs
+++ b/Almanac/Crops/VanillaProvider.cs
@@ -60,7 +60,7 @@ namespace Leclair.Stardew.Almanac.Crops {
 			if (!Game1.objectInformation.ContainsKey(harvest))
 				return null;
 
-			string[] seasons = bits[1].Split(' ');
+			string[] seasons = bits[1].Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
 			WorldDate startDate = null;
 			WorldDate endDate = null;

--- a/Almanac/FishHelper.cs
+++ b/Almanac/FishHelper.cs
@@ -107,7 +107,7 @@ namespace Leclair.Stardew.Almanac {
 		public static Dictionary<int, List<int>> GetLocationFish(int season, string data) {
 			Dictionary<int, List<int>> result = new();
 
-			string[] entries = data.Split('/')[4 + season].Split(' ');
+			string[] entries = data.Split('/')[4 + season].Split(' ', StringSplitOptions.RemoveEmptyEntries);
 
 			for (int i = 0; (i + 1) < entries.Length; i += 2) {
 				if (int.TryParse(entries[i], out int fish) && int.TryParse(entries[i + 1], out int zone))
@@ -115,6 +115,8 @@ namespace Leclair.Stardew.Almanac {
 						list.Add(fish);
 					else
 						result.Add(zone, new() { fish });
+				else
+					ModEntry.instance.Log($"Invalid fish data entry for season {season} (Fish ID:{entries[i]}, Zone:{entries[i + 1]})", LogLevel.Warn);
 			}
 
 			return result;

--- a/Almanac/FishHelper.cs
+++ b/Almanac/FishHelper.cs
@@ -110,13 +110,11 @@ namespace Leclair.Stardew.Almanac {
 			string[] entries = data.Split('/')[4 + season].Split(' ');
 
 			for (int i = 0; (i + 1) < entries.Length; i += 2) {
-				int fish = Convert.ToInt32(entries[i]);
-				int zone = Convert.ToInt32(entries[i + 1]);
-
-				if (result.TryGetValue(zone, out List<int> list))
-					list.Add(fish);
-				else
-					result.Add(zone, new() { fish });
+				if (int.TryParse(entries[i], out int fish) && int.TryParse(entries[i + 1], out int zone))
+					if (result.TryGetValue(zone, out List<int> list))
+						list.Add(fish);
+					else
+						result.Add(zone, new() { fish });
 			}
 
 			return result;

--- a/Almanac/FishHelper.cs
+++ b/Almanac/FishHelper.cs
@@ -5,6 +5,7 @@ using System.Text;
 using System.Threading.Tasks;
 
 using StardewValley;
+using StardewModdingAPI;
 
 using SObject = StardewValley.Object;
 


### PR DESCRIPTION
Had another issue with invalid data- this time, fish. Made a simple change that allows the fish helper to skip and log bad entries.
([Log for reference](https://smapi.io/log/e275f49af43c4b2dbbacd53dda318168))

Also discovered the root of the previous issue with crops- some crop seasons had extra spaces which were being parsed as empty strings. added a fix for that too, and a similar fix for fish data.