### PR TITLE
[Almanac] Add French translation

### DIFF
--- a/Almanac/Fish/FishingPage.cs
+++ b/Almanac/Fish/FishingPage.cs
@@ -537,7 +537,7 @@ public class FishingPage : BasePage<FishingState>, ILeftFlowMargins {
 					)
 					.Text(" ")
 					.Text(
-						Game1.content.LoadString(@"Strings\StringsFromCSFiles:SkillsPage.cs.11607"),
+						Game1.content.LoadString(@"Strings\StringsFromCSFiles:Farmer.cs.1993"),
 						bold: true
 					)
 					.Build();

--- a/Almanac/i18n/fr.json
+++ b/Almanac/i18n/fr.json
@@ -1,0 +1,415 @@
+{
+	"mod-name": "Almanach",
+
+	"almanac.open": "Ouvrir l'Almanach",
+
+	"almanac.cover": "L'Almanach\ndu Fermier de\nFerngill",
+	"almanac.cover-island": "L'Almanach\ndu Fermier de\nFerngill et des\nÎles de Fern",
+
+	"calendar.when": "{{season}}, année {{year}}",
+
+	"calendar.day.1": "Lu",
+	"calendar.day.2": "Ma",
+	"calendar.day.3": "Me",
+	"calendar.day.4": "Je",
+	"calendar.day.5": "Ve",
+	"calendar.day.6": "Sa",
+	"calendar.day.7": "Di",
+
+	"page.crops": "Dates de plantation",
+
+	"crop.last-day": "Dernier jour pour :",
+
+	"crop.toggle": "Basculer {{mode}}",
+	"crop.paddy": "Bonus d'irrigation",
+
+	"page.crop.none": "Il n'y a aucune culture qui correspond à vos filtres actuels.",
+
+	"page.crop.seed-filter": "Filtrer par graines",
+	"page.crop.seed-filter.disabled": "Désactivé",
+	"page.crop.seed-filter.inventory": "Dans l'inventaire",
+	"page.crop.seed-filter.owned": "Possédé",
+
+	"crop.seed-filter": "Afficher uniquement les graines possédées",
+
+	"crop.using-none": "Les temps de croissance et les dates suivants supposent que vous n'avez ni engrais ni compétence.",
+	"crop.using-agri": "Les temps de croissance et les dates suivants supposent que vous êtes un {{agriculturist}}.",
+	"crop.using-speed": "Les temps de croissance et les dates suivants supposent que vous utilisez {{fertilizer}}.",
+	"crop.using-both": "Les temps de croissance et les dates suivants supposent que vous êtes un {{agriculturist}} et que vous utilisez {{fertilizer}}.",
+	"crop.using-paddy": "Ils supposent également que les cultures qui en bénéficient sont @Bcultivées près de l'eau@b.",
+
+	"crop.grow-time": "Pousse en {{count}} jours.",
+	"crop.harvests": "Jusqu'à {{count}} récoltes cette année.",
+	"crop.harvests-date": "Jusqu'à {{count}} récoltes cette année lorsque planté le {{date}}.",
+	"crop.last-date": "À planter au plus tard le {{date}}.",
+	"crop.regrow-time": "Repousse tous les {{count}} jours.",
+	"crop.paddy-note": "Pousse plus rapidement près de l'eau.",
+	"crop.giant-note": "Capable de pousser à une taille {{link}}.",
+	"crop.giant-hover": "@Bgéante@b",
+	"crop.trellis-note": "Nécessite un treillis.",
+
+	"page.weather": "Prévisions météo",
+	"page.weather-island": "Prévisions pour l'Île Gingembre",
+
+	"page.weather.pirates": "La Guilde des aventuriers a annoncé qu'elle s'attend à une activité pirate sur ou aux alentours de l'Île Gingembre aux dates suivantes:",
+
+	"festival.about": "Les festivals suivants sont prévus dans la région de Stardew Valley en {{season}} :",
+
+	"festival.when": "Quand :",
+	"festival.when-times": "de {{start}} à {{end}}",
+	"festival.where": "Où :",
+	"festival.date": "Date :",
+
+	"weather.sunny": "Soleil",
+	"weather.rain": "Pluie",
+	"weather.debris": "Vent",
+	"weather.lightning": "Orage",
+	"weather.festival": "Soleil",
+	"weather.snow": "Neige",
+
+	"page.train": "Horaires des trains",
+	"page.train.about": "@BAttention :@b Des trains passeront par la gare de Stardew Valley aux heures suivantes. Pour votre sécurité, restez toujours à l'écart des rails quand un train est présent.",
+
+	"page.train.notice": "Le service de train à la gare de Stardew Valley est suspendu tout au long du printemps en raison de la maintenance programmée de la voie ferrée.",
+
+	"page.fortune": "Chance",
+
+	"page.fortune.luck-awful": "Les esprits, mécontents, vont vous rendre la vie difficile.",
+	"page.fortune.luck-bad": "Les esprits, agacés, ne porteront chance à personne.",
+	"page.fortune.luck-neutral": "Les esprits sont en parfait équilibre. La journée est entre vos mains.",
+	"page.fortune.luck-good": "Les esprits, de bonne humeur, apporteront un supplément de chance.",
+	"page.fortune.luck-great": "Les esprits, heureux, apporteront de la chance à tout le monde.",
+
+	"page.fortune.event.none": "Attendez-vous à une saison paisible. Vous devez trouver l'excitation en vous et chercher la joie dans votre vie quotidienne.",
+
+	"page.fortune.about": "Voici ce qui pourrait se passer en {{Season}}, ou ce qui pourrait ne pas se passer.",
+
+	"page.fortune.garbage-hat": "Les poubelles des uns font les trésors des autres.",
+
+	"page.fortune.event.fairy": "Une bonne fée de la nature passera dans la nuit. Ceux qui ont de la chance pourraient trouver une récolte abondante qui les attend.",
+	"page.fortune.event.witch": "Des sorcières sont attendues dans la région cette nuit-là.",
+	"page.fortune.event.meteorite": "Une pluie de météorites est attendue sur Ferngill.",
+	"page.fortune.event.owl": "Entourés de mystère, des gardiens de pierre descendent sur la vallée.",
+	"page.fortune.event.ufo": "Des êtres étranges venus d'au-delà du ciel survolent Ferngill.",
+
+	"page.mines": "Monde souterrain",
+	"page.mines.about": "Voici un résumé de l'activité des monstres prévue en {{Season}} :",
+
+	"page.mines.type.Mushroom": "Champignons",
+	"page.mines.type.InfestedMonster": "Infestation",
+	"page.mines.type.InfestedSlime": "Infestation de slimes",
+	"page.mines.type.Quarry": "Carrière",
+	"page.mines.type.InfestedQuarry": "Carrière infestée",
+	"page.mines.type.Dino": "Caverne de dinosaures",
+
+	"page.error": "Erreur",
+	"page.error.desc": "Une erreur est survenue dans cette page de menu. Consultez le journal du jeu pour plus de détails.",
+
+	"page.notices": "Annonces locales",
+
+	"page.notices.birthday-error": "Une erreur s'est produite lors du chargement de la liste des personnages. Les anniversaires ne peuvent pas être affichés. Consultez le journal du jeu pour plus de détails.",
+
+	"page.notices.season": "La saison des {{item}} s'étend du {{start}} au {{end}}.",
+	"page.notices.summer": "Les courants océaniques d'été devraient entraîner des débris supplémentaires sur la plage de Pelican Ville du 12 au 14.",
+	"page.notices.market": "Le marché nocturne est ouvert en soirée du 15 au 17.",
+
+	"page.notices.anniversary.no-s": "C'est l'anniversaire de mariage de {{name}} et {{spouse}} !",
+	"page.notices.anniversary.s": "C'est l'anniversaire de mariage de {{name}} et {{spouse}} !",
+
+	"page.notices.wedding.no-s": "C'est le mariage de {{name}} et {{spouse}} !",
+	"page.notices.wedding.s": "C'est le mariage de {{name}} et {{spouse}} !",
+
+	"page.notices.festival": "C'est l'heure du festival : {{name}} ! Rejoignez-nous à {{where}} entre {{start}} et {{end}}.",
+
+	"page.notices.birthday.no-s": "C'est l'anniversaire de {{name}} !",
+	"page.notices.birthday.s": "C'est l'anniversaire de {{name}} !",
+
+	"page.notices.merchant": "Le marchand itinérant sera en ville.",
+	"page.notices.merchant.stock": "Le marchand itinérant vendra :",
+
+	"page.notices.train": "Un train doit passer en gare à {{time}}.",
+
+	// Fishing Page
+
+	"page.fish": "Pêche",
+	"page.fish.aquarium.none": "Ce spécimen ne peut pas être placé dans un aquarium.",
+	"page.fish.caught": "Vous avez attrapé @B{{count}}@b spécimen comme celui-ci.",
+	"page.fish.caught.not": "Vous n'avez pas encore attrapé ce spécimen.",
+
+	// TL Note: You can use {{big_cm}}, {{min_cm}}, and {{max_cm}} instead of _inch.
+	"page.fish.size": "Votre plus grosse prise mesurait @B{{big_cm}} cm@b.",
+	"page.fish.size.range": "Il mesure entre @B{{min_cm}} cm@b et @B{{max_cm}} cm@b.",
+
+	"page.fish.weather.Sunny": "Le spécimen {{fish}} est seulement actif par temps @Bensoleillé@b.",
+	"page.fish.weather.Rainy": "Le spécimen {{fish}} est seulement actif par temps @Bpluvieux@b.",
+	"page.fish.weather.Any": "Le spécimen {{fish}} est toujours actif, qu'il pleuve ou qu'il fasse beau.",
+	"page.fish.level": "Vous avez besoin d'un niveau de {{skill}} de @B{{level}}@b pour l'attraper.",
+	"page.fish.legendary": "{{fish}} est un poisson légendaire.",
+	"page.fish.time.all": "Il est actif à tout moment de la journée.",
+	"page.fish.time": "Il est actif de @B{{start}}@b à @B{{end}}@b.",
+	"page.fish.time.many": "Il est actif aux moments suivants : {{spans}}.",
+	"page.fish.time.range": "de @B{{start}}@b à @B{{end}}@b",
+	"page.fish.locations": "Emplacements",
+	"page.fish.seasons.all": "Toutes les saisons",
+	"page.fish.locations.none": "Ce spécimen n'a pas de données d'emplacement.",
+	"page.fish.pond": "Aquaculture",
+	"page.fish.pond.none": "{{fish}} ne peut pas être placé dans un étang à poissons.",
+	"page.fish.pond.start": "",
+	"page.fish.filter.weather": "Filtrer par temps",
+	"page.fish.filter.none": "Non filtré",
+	"page.fish.none": "Il n'y a aucun spécimen qui correspond à vos filtres actuels.",
+	"page.fish.nothing": "Rien à voir ici...",
+	"fish.weather.Any": "N'importe",
+	"fish.weather.Rainy": "Pluie",
+	"fish.weather.Sunny": "Soleil",
+	"page.fish.filter.type": "Filtrer par type",
+	"page.fish.filter.type.trap": "Piège (Casier à crabes)",
+	"page.fish.filter.type.caught": "Pêche (Canne à pêche)",
+	"page.fish.filter.caught": "Filtrer par prise",
+	"page.fish.filter.true": "Oui",
+	"page.fish.filter.false": "Non",
+	"page.fish.filter.location": "Filtrer par emplacement actuel",
+	"page.fish.filter.now": "Oui, cette saison",
+	"page.fish.location.fresh": "Le spécimen {{fish}} vit en eau douce.",
+	"page.fish.location.ocean": "Le spécimen {{fish}} vit en eau salée.",
+
+	"page.fish.filter.aquarium": "Filtrer par don à l'aquarium",
+	"page.fish.aquarium.true": "Donné uniquement",
+	"page.fish.aquarium.false": "Non donné uniquement",
+
+	"page.fish.aquarium.donated": "Vous avez donné ce spécimen à l'aquarium Stardew.",
+	"page.fish.aquarium.not-donated": "Vous n'avez pas donné ce spécimen à l'aquarium Stardew.",
+
+	// Settings
+
+	"settings.theme": "Thème de l'interface utilisateur",
+	"settings.theme-desc": "Ce thème d'interface utilisateur sera utilisé pour le menu de l'Almanach.",
+
+	"theme.automatic": "Automatique",
+	"theme.default": "Par défaut",
+
+	"settings.button": "Position du bouton Almanach",
+	"settings.button-desc": "Lorsqu'il n'est pas désactivé, un bouton pour ouvrir l'Almanach sera ajouté au menu de l'inventaire à cette position.",
+
+	"settings.button.Disabled": "Désactivé",
+	"settings.button.LeftTop": "En haut à gauche du menu",
+	"settings.button.LeftBottom": "En bas à gauche du menu",
+	"settings.button.OrganizeRight": "À droite du bouton Organiser",
+	"settings.button.TrashRight": "À droite de la poubelle",
+	"settings.button.TrashDown": "En dessous de la poubelle",
+
+	"settings.unlimited": "Illimité",
+	"settings.days": "{{count}} jours",
+
+	"settings.available": "Almanach toujours disponible",
+	"settings.available-desc": "Lorsque activé, l'Almanach sera toujours disponible, que vous en ayez reçu un exemplaire ou non.",
+
+	"settings.island": "Page de l'île toujours disponible",
+	"settings.island-desc": "Lorsque activé, l'Almanach affichera toujours le contenu de l'île Gingembre, que vous ayez vu l'événement avec Willy ou non",
+
+	"settings.magic": "Pages magiques toujours disponibles",
+	"settings.magic-desc": "Lorsque activé, l'Almanach affichera toujours le contenu magique, que vous ayez vu l'événement avec le sorcier ou non.",
+
+	"settings.forecast-length": "Horizon de prévision",
+	"settings.forecast-length.desc": "Prévision jusqu'à ce nombre de jours dans le futur.",
+
+	"settings.weather.deterministic": "Utiliser une météo déterministe",
+	"settings.weather.deterministic-desc": "Pour que la prévision météo de l'Almanach fonctionne, nous remplaçons le calcul de la météo du lendemain par un autre qui utilise une source de hasard prévisible. Si cela pose problème, vous pouvez désactiver ce comportement ici. Cependant, cela désactivera la prévision météo étendue.",
+
+	"settings.weather.rules": "Activer les règles météo",
+	"settings.weather.rules-desc": "Les règles météo appliquent des contraintes supplémentaires à la météo aléatoire. Les règles par défaut garantissent un trio de jours pluvieux vers la fin du printemps pour faciliter l'amélioration des arrosoirs, ainsi qu'au moins un jour de pluie et au moins un jour ensoleillé chaque semaine.",
+
+	"settings.controls": "Contrôles",
+
+	"settings.controls.almanac": "Ouvrir l'Almanach",
+	"settings.controls.almanac-desc": "Appuyer sur cette touche ouvrira l'interface de l'Almanach.",
+
+	"settings.enable": "Activer la page",
+	"settings.enable-desc": "Détermine si cette page doit être ajoutée à l'Almanach.",
+
+	"settings.crops": "Page : Dates de plantation",
+
+	"settings.crops.preview": "Aperçus des cultures",
+	"settings.crops.preview-desc": "Lorsque les aperçus des cultures sont activés, survoler une culture sur la page 'Dates de plantation' vous montrera sur le calendrier à quelle étape la culture sera le jour donné.",
+
+	"settings.crops.preview.enable": "Activer les aperçus",
+
+	"settings.crops.preview.plantonfirst": "Toujours planter le premier",
+	"settings.crops.preview.plantonfirst-desc": "Lorsque activé, l'aperçu que vous voyez lorsqu'une culture est survolée commencera toujours la plantation le premier jour de la saison, même si la date actuelle est postérieure à celui-ci.",
+
+	"settings.crops.preview.sprite": "Utiliser les images de récolte",
+	"settings.crops.preview.sprite-desc": "Lorsque activé, une image du produit de la récolte sera utilisée plutôt que le stade de croissance final, afin de rendre plus évident les jours où la culture peut être récoltée.",
+
+	"settings.fortune": "Page : Chance",
+
+	"settings.fortune.deterministic": "Utiliser une chance déterministe",
+	"settings.fortune.deterministic-desc": "Pour que les prédictions de chance quotidienne de l'Almanach fonctionnent, nous remplaçons le calcul de la fortune quotidienne par un calcul utilisant une source de hasard prévisible. Si cela pose des problèmes, vous pouvez désactiver ce comportement ici. Cependant, cela désactivera les prévisions de chance quotidienne.",
+
+	"settings.fortune.exact": "Afficher les pourcentages de chance",
+	"settings.fortune.exact-desc": "Lorsque activé, le pourcentage exact de chance quotidienne sera affiché dans les infobulles du calendrier de la page de chance",
+
+	"settings.train": "Page : Horaires des trains",
+
+	"settings.weather": "Page : Prévisions météo",
+
+	"settings.mines": "Page : Monde souterrain",
+
+	"settings.fish": "Page : Pêche",
+	"settings.fish.show-tank": "Afficher l'aperçu de l'aquarium",
+	"settings.fish.show-tank-desc": "Lorsque activé, la page de pêche affichera un aperçu de l'apparence de chaque poisson dans un aquarium.",
+
+	"settings.fish.decorate-tank": "Décorer l'aquarium",
+	"settings.fish.decorate-tank-desc": "Lorsque activé, l'aperçu de l'aquarium contiendra quelques éléments décoratifs en plus des poissons.",
+
+	"settings.fish.legendary": "Inclure les poissons légendaires",
+	"settings.fish.legendary-desc": "Lorsque activé, les poissons légendaires seront également répertoriés dans l'Almanach.",
+
+	"settings.notices": "Page : Annonces locales",
+
+	"settings.notices.trains": "Afficher les trains",
+	"settings.notices.trains-desc": "Lorsque activé, les horaires des trains seront répertoriées dans les annonces locales. Cela peut être utilisé comme une alternative à la page des horaires des trains.",
+
+	"settings.notices.anniversaries": "Afficher les anniversaires",
+	"settings.notices.anniversaries-desc": "Lorsque activé, les mariages et les anniversaires de tous les fermiers seront répertoriées dans les annonces locales.",
+
+	"settings.notices.festivals": "Afficher les festivals",
+	"settings.notices.festivals-desc": "Lorsque activé, les festivals seront répertoriées dans les annonces locales.",
+	"settings.notices.gathering": "Afficher les rassemblements",
+	"settings.notices.gathering-desc": "Lorsque activé, les occasions de rassemblement seront répertoriées dans les annonces locales.",
+
+	"settings.notices.merchant": "Afficher le marchand itinérant",
+	"settings.notices.merchant-desc": "Lorsque activé, les visites du marchand itinérant seront répertoriées dans les annonces locales. Si vous le souhaitez, vous pouvez également afficher les articles qu'il aura en stock.",
+	"settings.notices.merchant.Disabled": "Désactivé",
+	"settings.notices.merchant.Visit": "Afficher uniquement les visites",
+	"settings.notices.merchant.Stock": "Afficher les visites et le stock",
+
+	"settings.restore-state": "Restaurer l'état précédent",
+	"settings.restore-state.desc": "Lorsque activé, l'Almanach se souviendra de son état lorsque vous le fermerez puis le restaurera lorsque vous le rouvrirez.",
+
+	"settings.cycle-time": "Intervalle de rotation",
+	"settings.cycle-time.desc": "Lorsque plusieurs images doivent être affichées un jour donné, chaque image est affichée pendant ce nombre de secondes.",
+
+	"settings.debug": "Mode de débogage",
+	"settings.debug.desc": "Lorsque activé, des informations supplémentaires peuvent être affichées dans l'Almanach, ce qui est utile pour le débogage. Le mode de débogage permet également d'appuyer sur F5 pour actualiser les données.",
+
+	// Events
+
+	// Pierre at Farm
+	"event.11022000.0": "Bonjour, @. On dirait que tu t'es bien installé !^Bonjour, @. On dirait que tu t'es bien installée !",
+	"event.11022000.1": "Ma livraison de l'Almanach du Fermier de cette année vient d'arriver. Comme tu es nouveau, j'ai pensé t'apporter un exemplaire.^Ma livraison de l'Almanach du Fermier de cette année vient d'arriver. Comme tu es nouvelle, j'ai pensé t'apporter un exemplaire.",
+	"event.11022000.2": "Vous avez reçu un exemplaire de l'Almanach du Fermier.",
+	"event.11022000.3": "Il regorge d'informations utiles : prévisions météorologiques, rotations de cultures, horaires des trains régionaux...",
+	"event.11022000.4": "Assure-toi de bien te renseigner sur ce que tu peux cultiver. Une fois que tu es prêt à planter, tu peux venir acheter des graines dans ma boutique.^Assure-toi de bien te renseigner sur ce que tu peux cultiver. Une fois que tu es prête à planter, tu peux venir acheter des graines dans ma boutique.#$b#Les graines de Pierre sont les *meilleures* que tu puisses trouver.",
+
+	// Wizard at Farm
+	"event.11022002.0": "Bonjour... @. Je t'attendais.#$b#J'aimerais te donner quelque chose.",
+	"event.11022002.1": "Vous avez reçu un exemplaire de l'Almanach magique.",
+	"event.11022002.2": "En tant que fermier, tu es familier avec les prévisions.^En tant que fermière, tu es familière avec les prévisions.#$b#Cet almanach contient une prévision spirituelle rédigée par Welwick elle-même.#$b#Il t'aidera à rester en sécurité et à te développer.",
+	"event.11022002.3": "Maintenant, si tu veux bien m'excuser... j'ai du travail.",
+
+	// Willy at FishShop
+	"event.11022001.0": "Ohé !",
+	"event.11022001.1": "Tu vas sur l'île ?",
+	"event.11022001.2": "J'ai quelque chose qui pourrait t'intéresser. Tiens.",
+	"event.11022001.3": "Vous avez reçu un exemplaire de l'Almanach des Îles de Fern.",
+	"event.11022001.4": "C'est pas grand-chose, mais savoir quel temps il fera, c'est génial. Certains poissons ne sortent que sous la pluie, tu sais ?",
+	"event.11022001.5": "Bon, je ne vais pas te retenir plus longtemps. Passe une bonne journée, @.",
+
+	// Times
+	// If this is set, we'll use a custom format for times displayed by Almanac
+	// rather than using the game's built-in getTimeOfDayString method.
+	// See https://stardewvalleywiki.com/Modding:Custom_languages#Data_format for
+	// details. (Specifically, TimeFormat in the data format table.)
+	"time-format": "",
+
+	// Locations
+
+	"location.WitchSwamp": "Marais de la sorcière",
+	"location.BugLand": "Repaire des insectes mutants",
+
+	"location.Caldera": "Île Gingembre (Cratère du volcan)",
+	"location.IslandWest": "Île Gingembre Ouest",
+	"location.IslandNorth": "Île Gingembre Nord",
+	"location.IslandSouth": "Île Gingembre Sud",
+	"location.IslandSouthEast": "Île Gingembre Sud-Est",
+	"location.IslandSouthEastCave": "Île Gingembre Sud-Est (Caverne)",
+	"location.IslandEast": "Île Gingembre Est",
+
+	"location.Submarine": "Sous-marin",
+
+	"location.sub-any": "N'importe où",
+	"location.sub-floor": "Niveau {{floor}}",
+
+	"location.Forest.River": "Rivière",
+	"location.Forest.Pond": "Étang",
+
+	"location.Island.Ocean": "Océan",
+	"location.Island.Freshwater": "Eau douce",
+
+	// Maps: Stardew Aquarium
+	"location.Custom_ExteriorMuseum": "Aquarium Stardew",
+
+	// Maps: Stardew Valley Expanded
+	"location.Custom_AdventurerSummit": "Sommet de l'aventurier",
+	"location.Custom_BlueMoonVineyard": "Vignoble Blue Moon",
+	"location.Custom_BlueMoonVineyard.0": "Océan",
+	"location.Custom_BlueMoonVineyard.1": "Rivière",
+	"location.Custom_CrimsonBadlands": "Terres Maudites Écarlates",
+	"location.Custom_FableReef": "Récif des Fables",
+	"location.Custom_ForestWest": "Forêt Sève-Cendreuse Ouest",
+	"location.Custom_Highlands": "Hautes-Terres",
+	"location.Custom_Highlands.0": "Ruines",
+	"location.Custom_Highlands.1": "Rivière",
+	"location.Custom_HighlandsCavern": "Hautes-Terres (Caverne)",
+	"location.Custom_JunimoWoods": "Forêt des Junimos",
+	//"location.Custom_MorrisProperty": "",
+	"location.Custom_ShearwaterBridge": "Pont de Shearwater",
+	"location.Custom_SpriteSpring2": "Source des esprits",
+	"location.Custom_GrampletonSuburbs": "Banlieue de Grampleton",
+	"location.Custom_GrampletonSuburbsTrainStation": "Banlieue de Grampleton (Gare)",
+
+	// Maps: East Scarpe
+	"location.Custom_EastScarpe": "East Scarp",
+	"location.Custom_EastScarpe.0": "Étang",
+	"location.Custom_EastScarpe.1": "Mares résiduelles",
+	"location.Custom_EastScarpe.2": "Océan",
+	"location.Custom_ESDeepDark": "East Scarp (Caverne de l'obscurité profonde)",
+	"location.Custom_ESDeepMountains": "Montagnes profondes",
+	"location.Custom_ESClearingHouse": "Vignoble",
+	"location.Custom_ESMeadowFarm": "Ferme de la prairie",
+	"location.Custom_ESVineyard": "Vignoble",
+	"location.Custom_ESMineEntrance": "East Scarp (Entrée des mines)",
+	"location.Custom_ESSeaCave": "East Scarp (Grotte marine)",
+	"location.Custom_ESSmugglerDen": "Repaire des contrebandiers",
+	"location.Custom_ESOrchard": "Verger de cerisiers",
+
+	// Maps: Ridgeside Village
+	"location.Custom_Ridgeside_RidgesideVillage": "Ridgeside Village",
+	"location.Custom_Ridgeside_RSVSewers": "Ridgeside Village (Égouts)",
+	"location.Custom_Ridgeside_Ridge": "La Crête",
+	"location.Custom_Ridgeside_RidgeFalls": "Chutes de la Crête",
+	"location.Custom_Ridgeside_RidgeForest": "Forêt de la Crête",
+	"location.Custom_Ridgeside_RidgePond": "Étang de la Crête",
+	"location.Custom_Ridgeside_SummitFarm": "Ferme du sommet",
+
+	// Maps: Downtown Zuzu
+	"location.Custom_DTZ_Forest1": "Forêt de Zuzu",
+	"location.Custom_DTZ_Forest2": "Forêt de Zuzu",
+	//"location.Custom_DTZ_Forest1.1": "",
+	"location.Custom_DTZ_ResortSouth": "Complexe de Kahuna",
+	"location.Custom_DTZ_ZuzuCityOasis1": "Désert de Zuzu",
+	"location.Custom_DTZ_Waterway": "Zuzu Ville",
+
+	// Maps: Dam
+	"location.Custom_Dam": "Barrage",
+	//"location.Custom_Dam_AfforestationArea": "Zone de boisement du barrage",
+	//"location.Custom_Dam_Cliff": "Falaise du barrage",
+	//"location.Custom_Dam_Road": "Route vers le barrage",
+
+	// Maps: Flooded Cave
+	"location.Custom_Flooded_Cave": "Grotte inondée",
+
+	// Maps: Tristan
+	"location.Custom_LK_SecretCave": "Forêt secrète (Caverne)",
+	"location.Custom_LK_FairyPool": "Forêt secrète (Bassin des Fées)"
+}


### PR DESCRIPTION
Added French translation.

Please note that the key `SkillsPage.cs.11607` from **StringsFromCSFiles** has been replaced by the key `Farmer.cs.1993`.  The values of these two keys are identical for all languages except French, for which the value of the key `SkillsPage.cs.11607` is `Pêche\n` with the `\n` breaking the display in the Almanac, whereas the value of the key `Farmer.cs.1993` is just `Pêche`.