### PR TITLE
Also set CraftingRecipe field (if possible) for SpaceCore recipes (fix YACS integration)

### DIFF
--- a/BetterCrafting/Integrations/SpaceCore/SCRecipe.cs
+++ b/BetterCrafting/Integrations/SpaceCore/SCRecipe.cs
@@ -42,6 +42,12 @@ public class SCRecipe : IRecipe {
 		string? test = recipe.Description;
 		Texture2D testtwo = recipe.IconTexture;
 		Rectangle? testthree = recipe.IconSubrect;
+
+		if (Cooking ?
+				CraftingRecipe.cookingRecipes.ContainsKey(name) :
+				CraftingRecipe.craftingRecipes.ContainsKey(name)) {
+			this.CraftingRecipe = new CraftingRecipe(name, Cooking);
+		}
 	}
 
 	#region Identity
@@ -67,7 +73,7 @@ public class SCRecipe : IRecipe {
 		return 0;
 	}
 
-	public CraftingRecipe? CraftingRecipe => null;
+	public CraftingRecipe? CraftingRecipe { get; }
 
 	#endregion
 

--- a/Common/Common.projitems
+++ b/Common/Common.projitems
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects Condition="'$(MSBuildVersion)' == '' Or '$(MSBuildVersion)' &lt; '16.0'">$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -15,9 +15,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)DynamicRecipeSpriteInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Crafting\IRecyclable.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Events\ConsoleCommand.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)events\GSQCondition.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Events\GSQCondition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Events\PintailModSubscriber.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)events\TriggerAction.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Events\TriggerAction.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\EventExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\NameValueCollectionExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\RandomExtensions.cs" />
@@ -26,16 +26,16 @@
     <Compile Include="$(MSBuildThisFileDirectory)Inventory\BuildingProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MultipleEventedInventoryExclusiveRequest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ReflectionHelper.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)serialization\AbstractConverter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Serialization\AbstractConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Serialization\Converters\DiscriminatingConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SmokedFishSpriteInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TextureColorWatcher.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)types\ModAssetEditor.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)types\ValueEqualityDictionary.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)types\ValueEqualityList.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)types\ValueStringBuilder.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)ui\simplelayout\AttachmentSlotsNode.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)ui\simplelayout\DynamicDrawingNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\ModAssetEditor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\ValueEqualityDictionary.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\ValueEqualityList.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Types\ValueStringBuilder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\SimpleLayout\AttachmentSlotsNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\SimpleLayout\DynamicDrawingNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SpookyActionAtADistance.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Types\AbsolutePosition.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CombinedRingSpriteInfo.cs" />
@@ -63,7 +63,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)UI\KMargins.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\KSize.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\SimpleLayout\ComponentSNode.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)ui\simplelayout\EmptyNode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)UI\SimpleLayout\EmptyNode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\Widgets\IKLayoutItem.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\Widgets\KLayout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)UI\Widgets\KObject.cs" />


### PR DESCRIPTION
Set the field to the vanilla equivalent if possible.

This fixes [Yet Another Cooking Skill](https://www.nexusmods.com/stardewvalley/mods/22681)'s integration with SpaceCore recipes added by Better Crafting. YACS was expecting this field to be set, which it is for vanilla recipes but not SC ones ([code snippet](https://github.com/Pet-Slime/StardewValley/blob/64eebbae76ade973b28bb597fbb02e79569a1cb5/CookingSkillRedux/Core/Events.cs#L65,L76)).

Also sneaked in changes to `Common.projitems` to make this mod build on Linux's case sensitive file system. Please let me know if I should take it out.