### PR TITLE
[Better Crafting] Fix SpaceCore recipes not showing crafted count

### DIFF
--- a/BetterCrafting/Integrations/SpaceCore/SCRecipe.cs
+++ b/BetterCrafting/Integrations/SpaceCore/SCRecipe.cs
@@ -25,14 +25,14 @@ public class SCRecipe : IRecipe {
 		Cooking = cooking;
 		Ingredients = ingredients.ToArray();
 
-		Item? example = CreateItem();
-		SortValue = $"{example?.ParentSheetIndex ?? 0}";
-		QuantityPerCraft = example?.Stack ?? 1;
-		Stackable = (example?.maximumStackSize() ?? 1) > 1;
+		ExampleItem = CreateItem();
+		SortValue = $"{ExampleItem?.ParentSheetIndex ?? 0}";
+		QuantityPerCraft = ExampleItem?.Stack ?? 1;
+		Stackable = (ExampleItem?.maximumStackSize() ?? 1) > 1;
 
 		if (recipe.Name != null)
 			DisplayName = recipe.Name;
-		else if (example is not null && ItemRegistry.GetData(example.QualifiedItemId) is ParsedItemData data)
+		else if (ExampleItem is not null && ItemRegistry.GetData(ExampleItem.QualifiedItemId) is ParsedItemData data)
 			DisplayName = data.DisplayName;
 		else
 			DisplayName = Name;
@@ -57,7 +57,7 @@ public class SCRecipe : IRecipe {
 
 	public virtual int GetTimesCrafted(Farmer who) {
 		if (Cooking) {
-			if (who.recipesCooked.TryGetValue(Name, out int count))
+			if (who.recipesCooked.TryGetValue(ExampleItem?.ItemId ?? Name, out int count))
 				return count;
 			return 0;
 

--- a/BetterCrafting/Managers/ItemCacheManager.cs
+++ b/BetterCrafting/Managers/ItemCacheManager.cs
@@ -59,7 +59,7 @@ public class ItemCacheManager : BaseManager {
 
 		items = ItemQueryResolver.TryResolve(
 			data,
-			new ItemQueryContext(Game1.player.currentLocation, Game1.player, Game1.random),
+			new ItemQueryContext(Game1.player.currentLocation, Game1.player, Game1.random, $"Better Crafting ingredient ${id}"),
 			avoidRepeat: false,
 			logError: (query, error) => {
 				Mod.Log($"Error attempting to resolve ingredient with query '{query}': {error}", LogLevel.Error);

--- a/BetterCrafting/Models/DataRecipe.cs
+++ b/BetterCrafting/Models/DataRecipe.cs
@@ -82,7 +82,7 @@ public class DataRecipe : IRecipe {
 						if (ingredient.RecycleItem != null)
 							recycleTo = delegate () {
 								if (string.IsNullOrEmpty(ingredient.RecycleItem.Condition) || GameStateQuery.CheckConditions(ingredient.RecycleItem.Condition, Game1.currentLocation, Game1.player)) {
-									var ctx = new ItemQueryContext(Game1.currentLocation, Game1.player, Game1.random);
+									var ctx = new ItemQueryContext(Game1.currentLocation, Game1.player, Game1.random, $"Better Crafting recipe {Name}");
 									Item result = ItemQueryResolver.TryResolveRandomItem(ingredient.RecycleItem, ctx, avoidRepeat: false, null, null, null, (query, error) => {
 										Mod.Log($"Error attempting to spawn item for custom recipe {Name} with query '{query}': {error}", LogLevel.Error);
 									});
@@ -200,7 +200,7 @@ public class DataRecipe : IRecipe {
 
 	public Item? CreateItem() {
 
-		var ctx = new ItemQueryContext(Game1.currentLocation, Game1.player, Game1.random);
+		var ctx = new ItemQueryContext(Game1.currentLocation, Game1.player, Game1.random, $"Better Crafting recipe {Name}");
 		foreach (var entry in Data.Output) {
 			if (string.IsNullOrEmpty(entry.Condition) || GameStateQuery.CheckConditions(entry.Condition, Game1.currentLocation, Game1.player)) {
 				Item result = ItemQueryResolver.TryResolveRandomItem(entry, ctx, avoidRepeat: false, null, null, null, (query, error) => {


### PR DESCRIPTION
This issue is caused by `GetTimesCrafted` checking for cooked count by the recipe `Name` instead of the item ID (which is how the game remembers cooking count, in contrast to crafting which uses `Name`).

Also fix BC to build on SDV 1.6.14 by adding the new required parameter for `ItemQueryContext`. Let me know if you want that to be a separate PR.